### PR TITLE
Bind to non-privileged port in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY --from=crane-builder /go/bin/crane /
 COPY --from=rust-builder /app/target/release/image-registry-checker /
 EXPOSE 80
 ENTRYPOINT ["./image-registry-checker"]
-CMD ["--port=80", "--ip=0.0.0.0", "--crane-cmd=/crane"]
+CMD ["--port=8080", "--ip=0.0.0.0", "--crane-cmd=/crane"]

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ docker build -t <YOUR_IMAGE_NAME> .
 ```
 This will take care of installing any build-time and run-time dependencies, so you do have to install rust or `crane`.
 
-The container will expose port 80 to accept incoming http requests. After starting the container, e.g. like this
+The container will expose port 8080 to accept incoming http requests. After starting the container, e.g. like this
 ```bash
-docker run --rm -p80:8080 <YOUR_IMAGE_NAME>
+docker run --rm -p8080:8080 <YOUR_IMAGE_NAME>
 ```
 you can check, if the service is up by visiting http://localhost:8080/health, which should return "OK".
 


### PR DESCRIPTION
This allows to run the web server as non-root user within the container.