### PR TITLE
Add simple local CVE scan utility

### DIFF
--- a/scan.sh
+++ b/scan.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 CRANE_VERSION=v0.13.0
+SEVERITY=MEDIUM,HIGH,CRITICAL
 
 # $ sh scan.sh image-registry-checker:latest
 
@@ -9,7 +10,7 @@ if [ ! -d trivy ]; then
  mkdir -p trivy && tar xf trivy_0.50.1_Linux-64bit.tar.gz -C trivy
 fi
 
-./trivy/trivy image --severity MEDIUM,HIGH,CRITICAL "$1"
-./trivy/trivy repo --severity MEDIUM,HIGH,CRITICAL image-registry-checker/
-./trivy/trivy repo --tag=${CRANE_VERSION} --severity MEDIUM,HIGH,CRITICAL github.com/google/go-containerregistry
+./trivy/trivy image --severity "$SEVERITY" "$1"
+./trivy/trivy repo --severity "$SEVERITY" image-registry-checker/
+./trivy/trivy repo --tag=${CRANE_VERSION} --severity "$SEVERITY" github.com/google/go-containerregistry
 

--- a/scan.sh
+++ b/scan.sh
@@ -10,7 +10,7 @@ if [ ! -d trivy ]; then
  mkdir -p trivy && tar xf trivy_0.50.1_Linux-64bit.tar.gz -C trivy
 fi
 
-./trivy/trivy repo --tag=${CRANE_VERSION} --severity "$SEVERITY" github.com/google/go-containerregistry
+./trivy/trivy repo --skip-dirs "cmd/krane,pkg/authn" --tag=${CRANE_VERSION} --severity "$SEVERITY" github.com/google/go-containerregistry
 ./trivy/trivy repo --severity "$SEVERITY" image-registry-checker/
 
 ./trivy/trivy image --severity "$SEVERITY" "$1"

--- a/scan.sh
+++ b/scan.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CRANE_VERSION=v0.13.0
-SEVERITY=MEDIUM,HIGH,CRITICAL
+SEVERITY=UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
 
 # $ sh scan.sh image-registry-checker:latest
 

--- a/scan.sh
+++ b/scan.sh
@@ -10,7 +10,8 @@ if [ ! -d trivy ]; then
  mkdir -p trivy && tar xf trivy_0.50.1_Linux-64bit.tar.gz -C trivy
 fi
 
-./trivy/trivy image --severity "$SEVERITY" "$1"
-./trivy/trivy repo --severity "$SEVERITY" image-registry-checker/
 ./trivy/trivy repo --tag=${CRANE_VERSION} --severity "$SEVERITY" github.com/google/go-containerregistry
+./trivy/trivy repo --severity "$SEVERITY" image-registry-checker/
+
+./trivy/trivy image --severity "$SEVERITY" "$1"
 

--- a/scan.sh
+++ b/scan.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+CRANE_VERSION=v0.13.0
+
+# $ sh scan.sh image-registry-checker:latest
+
+if [ ! -d trivy ]; then
+ wget --quiet https://github.com/aquasecurity/trivy/releases/download/v0.50.1/trivy_0.50.1_Linux-64bit.tar.gz
+ mkdir -p trivy && tar xf trivy_0.50.1_Linux-64bit.tar.gz -C trivy
+fi
+
+./trivy/trivy image --severity MEDIUM,HIGH,CRITICAL "$1"
+./trivy/trivy repo --severity MEDIUM,HIGH,CRITICAL image-registry-checker/
+./trivy/trivy repo --tag=${CRANE_VERSION} --severity MEDIUM,HIGH,CRITICAL github.com/google/go-containerregistry
+


### PR DESCRIPTION
This PR adds a simple local CVE scan utility (using [trivy](https://github.com/aquasecurity/trivy)) that checks for vulnerabilities in the app's dependencies. Helps to evaluate if the container image would pass e.g. image registry policies, before actually pushing to a registry that has CVE observation and policies enabled.